### PR TITLE
Fix LLVM Mingw build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+build
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,17 +13,20 @@ if(UNIX)
   # apt install libx11-dev libxext-dev
   # brew install libx11 xquartz
   find_package(X11 REQUIRED)
+elseif(WIN32)
+  string(REGEX MATCH "[0-9]+$" KC_WIN_BUILD ${CMAKE_SYSTEM_VERSION})
 endif()
 
 add_library(fw fw/pkb.c fw/sys.c
-$<$<BOOL:${WIN32}>:fw/wvid.c>
-$<$<BOOL:${UNIX}>:fw/xvid.c>
+  $<$<BOOL:${WIN32}>:fw/wvid.c>
+  $<$<BOOL:${UNIX}>:fw/xvid.c>
+)
+target_link_libraries(fw PRIVATE
+  $<$<BOOL:${UNIX}>:X11::Xext>
+  $<$<BOOL:${WIN32}>:winmm>
 )
 target_include_directories(fw PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/fw)
-target_link_libraries(fw PRIVATE
-$<$<BOOL:${UNIX}>:X11::Xext>
-$<$<BOOL:${WIN32}>:winmm>
-)
+target_compile_definitions(fw PRIVATE $<$<BOOL:${WIN32}>:KC_OS_WIN_BUILD=${KC_WIN_BUILD}>)
 
 add_library(pl clip.c gfx.c imode.c importer.c math.c pl.c)
 target_include_directories(pl PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/fw/fw.h
+++ b/fw/fw.h
@@ -53,8 +53,18 @@
 /***********************************************************************/
 
 #ifdef __cplusplus
-extern "C" {
+#define KC_BEGIN_C_HEADER FW_C_API {
+#define KC_END_C_HEADER }
+#define KC_C_API extern "C"
+#else
+#define KC_BEGIN_C_HEADER
+#define KC_END_C_HEADER
+#define KC_C_API
 #endif
+
+/***********************************************************************/
+
+KC_BEGIN_C_HEADER
 
 #ifndef NULL
 #define NULL ((void *)0)
@@ -64,6 +74,10 @@ extern "C" {
 #undef VOLATILE
 #endif
 #define VOLATILE volatile
+
+#ifndef FW_DEFAULT_TITLE_SIZE
+#define FW_DEFAULT_TITLE_SIZE 16
+#endif
 
 /***********************************************************************/
 
@@ -150,8 +164,6 @@ extern int pkb_key_held(int key);    /* this tests if key is being held */
 extern void FW_info(char *s, ...);  /* info message */
 extern void FW_error(char *s, ...); /* error message (halts program) */
 
-#ifdef __cplusplus
-}
-#endif
+KC_END_C_HEADER
 
 #endif

--- a/fw/fw_priv.h
+++ b/fw/fw_priv.h
@@ -21,9 +21,20 @@
 
 #include "fw.h"
 
-#ifdef __cplusplus
-extern "C" {
+#if FW_OS_TYPE_WINDOWS
+#ifdef KC_OS_WIN_BUILD
+#if KC_OS_WIN_BUILD >= 10240
+#define _WIN32_WINNT 0x0605
+#define WINVER 0x0605
+#else
+#error Windows >8.1 required for AdjustWindowRectExForDpi!
 #endif
+#endif /* KC_OS_WINVER */
+#endif /* FW_OS_TYPE_WINDOWS */
+
+/***********************************************************************/
+
+KC_BEGIN_C_HEADER
 
 #define FW_CALC_PITCH(w, bpp) ((((w) * (bpp)) + 3) & ~3)
 #define FW_BYTE_ALIGN(w, bpp) (FW_CALC_PITCH(w, bpp) / (bpp))
@@ -33,8 +44,6 @@ extern void pkb_poll(void);      /* gets called every loop */
 extern int wnd_osm_handle(void); /* poll the operating system for events */
 extern void wnd_term(void);      /* clean up and close the active window */
 
-#ifdef __cplusplus
-}
-#endif
+KC_END_C_HEADER
 
 #endif

--- a/fw/wvid.c
+++ b/fw/wvid.c
@@ -33,8 +33,9 @@
 #define NOKERNEL
 #define OEMRESOURCE
 #undef UNICODE
-#include <mmsystem.h>
+
 #include <windows.h>
+#include <mmsystem.h>
 
 #include <ctype.h>
 #include <inttypes.h>
@@ -48,9 +49,14 @@
 
 #define FW_CLASSNAME "FWLE"
 
+#if FW_DEFAULT_TITLE_SIZE < 6
+#error TITLE_SIZE Needs to be at least 6!
+#endif
+
 static char *
 FWi_strdup(char *src)
 {
+    const size_t X = WINVER; 
     size_t len;
     char *dst;
     len = strlen(src);
@@ -137,7 +143,7 @@ os_message_handler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 extern int
 vid_open(char *title, int width, int height, int scale, int flags)
 {
-    static LPCSTR default_title = "vFWLE";
+    static char default_title[FW_DEFAULT_TITLE_SIZE] = "vFWLE";
     static int cret = 0;
     WNDCLASSEX w = {0};
     HDC hdc;

--- a/pl.h
+++ b/pl.h
@@ -20,8 +20,16 @@
  */
 
 #ifdef __cplusplus
-extern "C" {
+#define KC_BEGIN_C_HEADER FW_C_API {
+#define KC_END_C_HEADER }
+#define KC_C_API extern "C"
+#else
+#define KC_BEGIN_C_HEADER
+#define KC_END_C_HEADER
+#define KC_C_API
 #endif
+
+KC_BEGIN_C_HEADER
 
 /* maximum possible horizontal or vertical resolution */
 #define PL_MAX_SCREENSIZE 2048
@@ -299,8 +307,6 @@ extern void *EXT_calloc(unsigned, unsigned);
 /* memory freeing function */
 extern void EXT_free(void *);
 
-#ifdef __cplusplus
-}
-#endif
+KC_END_C_HEADER
 
 #endif


### PR DESCRIPTION
Flipped windows includes, added explicit ``WINVER`` define in ``fw_priv.h`` with cmake support, changed ``vid_open::default_title`` to a mutable buffer.